### PR TITLE
Added optional uberenv install instructions

### DIFF
--- a/.uberenv_config.json
+++ b/.uberenv_config.json
@@ -1,0 +1,13 @@
+{
+"package_name" : "nlopt",
+"package_version" : "2.7.0",
+"package_final_phase" : "install",
+"package_source_dir" : "../..",
+"force_commandline_prefix" : false,
+"spack_url": "https://github.com/spack/spack.git",
+"spack_commit": "440fcb2a3addc367b2357eaec86d07d05c1a356c",
+"spack_configs_path": "scripts/spack/configs",
+"spack_packages_path": "scripts/spack/packages",
+"spack_activate" : {},
+"spack_concretizer": "clingo"
+}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,6 +40,7 @@ include(${PROJECT_SOURCE_DIR}/cmake/OpMacros.cmake)
 #------------------------------------------------------------------------------
 
 if (NLOPT_DIR)
+message("nlopt_dir: ${NLOPT_DIR}")
 blt_find_libraries( FOUND_LIBS NLOPT_LIB
                     NAMES      nlopt
                     REQUIRED   TRUE

--- a/README.md
+++ b/README.md
@@ -15,8 +15,19 @@ The following will install to `../install`.
 mkdir build
 cd build
 cmake -DBLT_SOURCE_DIR=<blt-dir> -C ../host_configs/quartz.cmake -DCMAKE_INSTALL_PREFIX=$PWD/../install ..
-
 ```
+
+### Optionally obtain nlopt
+```
+cd uberenv/
+python3 uberenv.py --prefix=../../op_uberenv_libs --install --spack-config-dir=scripts/spack/configs/linux_ubuntu_20/ --spec %gcc~python
+```
+
+Then to compile `nlopt`-related tests perform the following:
+```
+cmake -DNLOPT_DIR=../../op_uberenv_libs/nlopt-install ..
+```
+
 ## Using OP in another project
 The following `cmake` line can be added to `CMakeLists.txt` to find the required package. `OP_DIR` must be defined either as a cmake commandline option, in `CMakeCache.txt`, or in a toolchain file.
 


### PR DESCRIPTION
Users can obtain `nlopt` via provided uberenv script and compile `nlopt`-related tests using new instructions in the  `README.md`.